### PR TITLE
User target creation

### DIFF
--- a/__tests__/controllers/auth.controller.spec.ts
+++ b/__tests__/controllers/auth.controller.spec.ts
@@ -95,8 +95,8 @@ describe('AuthController', () => {
           UserErrorsMessages.USER_FIRST_NAME_STRING,
           UserErrorsMessages.USER_LAST_NAME_NOT_EMPTY,
           UserErrorsMessages.USER_LAST_NAME_STRING,
-          UserErrorsMessages.USER_GENDER_ENUM,
           UserErrorsMessages.USER_GENDER_NOT_EMPTY,
+          UserErrorsMessages.USER_GENDER_ENUM,
           ErrorsMessages.EMAIL_NOT_EMAIL,
           ErrorsMessages.PASSWORD_ERROR
         ],

--- a/__tests__/controllers/auth.controller.spec.ts
+++ b/__tests__/controllers/auth.controller.spec.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import app from '@app';
 import { API } from '../utils';
-import { ErrorsMessages } from '@constants/errorMessages';
+import { ErrorsMessages, UserErrorsMessages } from '@constants/errorMessages';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { AuthController } from '../../src/controllers/auth.controller';
 import { Container } from 'typedi';
@@ -91,12 +91,12 @@ describe('AuthController', () => {
       expect(response.body).toStrictEqual({
         description: ErrorsMessages.BODY_ERRORS,
         errors: [
-          ErrorsMessages.USER_FIRST_NAME_NOT_EMPTY,
-          ErrorsMessages.USER_FIRST_NAME_STRING,
-          ErrorsMessages.USER_LAST_NAME_NOT_EMPTY,
-          ErrorsMessages.USER_LAST_NAME_STRING,
-          ErrorsMessages.USER_GENDER_ENUM,
-          ErrorsMessages.USER_GENDER_NOT_EMPTY,
+          UserErrorsMessages.USER_FIRST_NAME_NOT_EMPTY,
+          UserErrorsMessages.USER_FIRST_NAME_STRING,
+          UserErrorsMessages.USER_LAST_NAME_NOT_EMPTY,
+          UserErrorsMessages.USER_LAST_NAME_STRING,
+          UserErrorsMessages.USER_GENDER_ENUM,
+          UserErrorsMessages.USER_GENDER_NOT_EMPTY,
           ErrorsMessages.EMAIL_NOT_EMAIL,
           ErrorsMessages.PASSWORD_ERROR
         ],

--- a/__tests__/controllers/targets.controller.spec.ts
+++ b/__tests__/controllers/targets.controller.spec.ts
@@ -66,12 +66,12 @@ describe('TargetController', () => {
         description: ErrorsMessages.BODY_ERRORS,
         httpCode: HttpStatusCode.BAD_REQUEST,
         errors: [
-          TargetErrorsMessages.TARGET_TITLE_MIN_LENGTH,
           TargetErrorsMessages.TARGET_TITLE_NOT_EMPTY,
           TargetErrorsMessages.TARGET_TITLE_STRING,
-          TargetErrorsMessages.TARGET_RADIUS_GREATER_0,
+          TargetErrorsMessages.TARGET_TITLE_MIN_LENGTH,
           TargetErrorsMessages.TARGET_RADIUS_NOT_EMPTY,
-          TargetErrorsMessages.TARGET_RADIUS_NUMBER
+          TargetErrorsMessages.TARGET_RADIUS_NUMBER,
+          TargetErrorsMessages.TARGET_RADIUS_GREATER_0
         ],
         name: ErrorsMessages.BAD_REQUEST_ERROR
       });

--- a/__tests__/controllers/targets.controller.spec.ts
+++ b/__tests__/controllers/targets.controller.spec.ts
@@ -1,0 +1,108 @@
+import request from 'supertest';
+import { factory } from 'typeorm-seeding';
+import { Container } from 'typedi';
+import app from '@app';
+import { User } from '@entities/user.entity';
+import { JWTService } from '@services/jwt.service';
+import { API } from '../utils';
+import { HttpStatusCode } from '@constants/httpStatusCode';
+import { getRepository } from 'typeorm';
+import { ErrorsMessages, TargetErrorsMessages } from '@constants/errorMessages';
+import { CreateTargetDTO } from '@dto/createTargetDTO';
+import { Target } from '@entities/target.entity';
+import { UnauthorizedError } from '@exception/unauthorized.error';
+import * as faker from 'faker';
+
+let jwtService = Container.get(JWTService);
+let user: User;
+let token: string;
+let createTargetDTO: CreateTargetDTO;
+
+describe('TargetController', () => {
+  beforeAll(async () => {
+    jwtService = Container.get(JWTService);
+    user = await factory(User)().create();
+    token = await jwtService.createJWT(user);
+    createTargetDTO = await factory(CreateTargetDTO)().make();
+  });
+
+  it('all dependencies should be defined', () => {
+    expect(jwtService).toBeDefined();
+  });
+
+  describe('createTarget', () => {
+    beforeEach(async () => {
+      user = await factory(User)().create();
+      token = await jwtService.createJWT(user);
+    });
+    it('returns http code 401 without authentication token', async () => {
+      const response = await request(app)
+        .post(`${API}/targets`);
+      expect(response.status).toBe(HttpStatusCode.UNAUTHORIZED);
+      expect(response.body).toStrictEqual(
+        expect.objectContaining(new UnauthorizedError('POST /api/v1/targets'))
+      );
+    });
+
+    it('returns http code 401 with an invalid authentication token', async () => {
+      const invalidToken = faker.random.word();
+      const response = await request(app)
+        .post(`${API}/targets`)
+        .set({ Authorization: invalidToken });
+      expect(response.status).toBe(HttpStatusCode.UNAUTHORIZED);
+      expect(response.body).toStrictEqual(
+        expect.objectContaining(new UnauthorizedError('POST /api/v1/targets'))
+      );
+    });
+
+    it('returns http code 400 with 6 errors on the errors field', async () => {
+      const response = await request(app)
+        .post(`${API}/targets`)
+        .set({ Authorization: token })
+        .send({});
+      expect(response.status).toBe(HttpStatusCode.BAD_REQUEST);
+
+      expect(response.body).toStrictEqual({
+        description: ErrorsMessages.BODY_ERRORS,
+        httpCode: HttpStatusCode.BAD_REQUEST,
+        errors: [
+          TargetErrorsMessages.TARGET_TITLE_MIN_LENGTH,
+          TargetErrorsMessages.TARGET_TITLE_NOT_EMPTY,
+          TargetErrorsMessages.TARGET_TITLE_STRING,
+          TargetErrorsMessages.TARGET_RADIUS_GREATER_0,
+          TargetErrorsMessages.TARGET_RADIUS_NOT_EMPTY,
+          TargetErrorsMessages.TARGET_RADIUS_NUMBER
+        ],
+        name: ErrorsMessages.BAD_REQUEST_ERROR
+      });
+    });
+
+    it('returns http code 400 if creating more than 10 targets', async () => {
+      for (let i = 0; i < 10; i++) {
+        createTargetDTO = await factory(CreateTargetDTO)().make();
+        await request(app)
+          .post(`${API}/targets`)
+          .set({ Authorization: token })
+          .send(createTargetDTO);
+      }
+      const response = await request(app)
+        .post(`${API}/targets`)
+        .set({ Authorization: token })
+        .send(createTargetDTO);
+      expect(response.status).toBe(HttpStatusCode.BAD_REQUEST);
+      expect(response.body.description).toContain(
+        TargetErrorsMessages.TARGET_USER_MORE_10
+      );
+    });
+
+    it('returns http code 200 and creates the target', async () => {
+      const response = await request(app)
+        .post(`${API}/targets`)
+        .set({ Authorization: token })
+        .send(createTargetDTO);
+      expect(response.status).toBe(HttpStatusCode.OK);
+      const targetRepo = getRepository<Target>(Target);
+      expect(await targetRepo.count()).toBeGreaterThan(0);
+    });
+  });
+});

--- a/__tests__/controllers/users.controller.spec.ts
+++ b/__tests__/controllers/users.controller.spec.ts
@@ -172,7 +172,7 @@ describe('UsersController', () => {
       const userFields = await factory(User)().create();
 
       const userRepo = getRepository<User>(User);
-      userRepo.clear();
+      userRepo.delete({});
 
       const validResponse = await request(app)
         .post(`${API}/users`)

--- a/__tests__/services/targets.service.spec.ts
+++ b/__tests__/services/targets.service.spec.ts
@@ -1,0 +1,104 @@
+/* eslint-disable max-len */
+import { Container } from 'typedi';
+import { TargetsService } from '@services/targets.service';
+import { getRepository, Repository } from 'typeorm';
+import { Target } from '@entities/target.entity';
+import { factory } from 'typeorm-seeding';
+import { User } from '@entities/user.entity';
+import { TargetNotSavedException } from '@exception/targets/target-not-saved.exception';
+import * as faker from 'faker';
+import { UsersService } from '@services/users.service';
+
+let targetsService: TargetsService;
+let usersService: UsersService;
+let targetRepository: Repository<Target>;
+let target: Target;
+let user: User;
+let numberOfTargets: number;
+
+describe('TargetsService', () => {
+  beforeAll(async () => {
+    targetsService = Container.get(TargetsService);
+    usersService = Container.get(UsersService);
+    targetRepository = getRepository<Target>(Target);
+    user = await factory(User)().create();
+    numberOfTargets = faker.datatype.number({
+      'min': 0,
+      'max': 9
+    });
+  });
+
+  it('all dependencies should be defined', () => {
+    expect(targetsService).toBeDefined();
+    expect(usersService).toBeDefined();
+  });
+
+  describe('canCreateTargets', () => {
+    it('should return true if targets < 10', async () => {
+      jest.spyOn(targetRepository, 'count')
+        .mockResolvedValueOnce(numberOfTargets);
+
+      const response = await targetsService.canCreateTargets(user.id);
+      expect(response).toBeTruthy();
+    });
+
+    it('should return false if targets >= 10', async () => {
+      numberOfTargets = faker.datatype.number({
+        'min': 10
+      });
+      jest.spyOn(targetRepository, 'count')
+        .mockResolvedValueOnce(numberOfTargets);
+
+      const response = await targetsService.canCreateTargets(user.id);
+      expect(response).toBeFalsy();
+    });
+
+    it('should return an error', async () => {
+      jest.spyOn(targetRepository, 'count')
+        .mockRejectedValueOnce(new Error('Test error'));
+
+      await expect(targetsService.canCreateTargets(user.id))
+        .rejects.toThrowError(Error);
+    });
+  });
+
+  describe('createTarget', () => {
+    beforeAll(async () => {
+      target = await factory(Target)().make();
+      user = await factory(User)().create();
+    });
+
+    it('should create the target', async () => {
+      jest.spyOn(targetsService, 'canCreateTargets')
+        .mockResolvedValueOnce(true);
+
+      jest.spyOn(targetRepository, 'save')
+        .mockResolvedValueOnce(target);
+
+      await expect(targetsService.createTarget(target, user.id))
+        .resolves.toBe(target);
+    });
+
+    it('should throw TargetNotSavedException when creating the target if error has ocurred', async () => {
+      jest.spyOn(targetsService, 'canCreateTargets')
+        .mockResolvedValueOnce(true);
+
+      jest.spyOn(targetRepository, 'save')
+        .mockRejectedValueOnce(new TargetNotSavedException('Test error'));
+
+      await expect(targetsService.createTarget(target, user.id))
+        .rejects.toThrowError(TargetNotSavedException);
+    });
+
+    it('should throw TargetNotSavedException when reaching more than 10 targets', async () => {
+      jest.spyOn(targetsService, 'canCreateTargets')
+        .mockResolvedValueOnce(false);
+
+      jest.spyOn(targetRepository, 'save')
+        .mockRejectedValueOnce(new TargetNotSavedException('Test error'));
+
+      await expect(targetsService.createTarget(target, user.id))
+        .rejects.toThrowError(TargetNotSavedException);
+    });
+  });
+});

--- a/__tests__/utils/mocks.ts
+++ b/__tests__/utils/mocks.ts
@@ -1,3 +1,4 @@
-import { UpdateResult } from 'typeorm';
+import { InsertResult, UpdateResult } from 'typeorm';
 
 export const mockUpdateResult = new UpdateResult();
+export const mockInsertResult = new InsertResult();

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ const routingControllersOptions: any = {
   defaultErrorHandler: false,
   cors: true,
   authorizationChecker: AuthorizationService.getInstance().authorizationChecker,
+  currentUserChecker: AuthorizationService.getInstance().currentUserChecker,
   controllers,
   middlewares,
   interceptors: []

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -22,8 +22,10 @@ export enum ErrorsMessages {
   BAD_REQUEST_ERROR = 'Bad request error',
   NOT_FOUND_ERROR = 'Not found error',
   NOT_ACCEPTABLE_ERROR = 'Not acceptable error',
-  UNAUTHORIZED_ERROR = 'AuthorizationRequiredError',
-  // USER ERRORS
+  UNAUTHORIZED_ERROR = 'AuthorizationRequiredError'
+}
+
+export enum UserErrorsMessages {
   USER_ALREADY_EXISTS = 'A user with this email is already registered',
   USER_FIRST_NAME_NOT_EMPTY = 'Property firstName should not be empty',
   USER_FIRST_NAME_STRING = 'Property firstName must be a string',
@@ -34,8 +36,19 @@ export enum ErrorsMessages {
   HASH_NOT_VALID = 'Please try again or request a new link',
   HASH_EXPIRED = 'The link has expired, please request a new one',
   USER_NOT_FOUND = 'The user cannot be found'
-
 }
+
+export enum TargetErrorsMessages {
+  TARGET_TITLE_MIN_LENGTH = 'Property title should have a minimum length of 4',
+  TARGET_TITLE_NOT_EMPTY = 'Property title should not be empty',
+  TARGET_TITLE_STRING = 'Property title must be a string',
+  TARGET_RADIUS_GREATER_0 = 'Property radius must be greater than 0',
+  TARGET_RADIUS_NOT_EMPTY = 'Property radius should not be empty',
+  TARGET_RADIUS_NUMBER = 'Property radius must be a number',
+  TARGET_NOT_SAVED = 'The target could not be saved',
+  TARGET_USER_MORE_10 = 'Cannot create more than 10 targets'
+}
+
 
 export const Errors = {
   [ErrorsMessages.MISSING_PARAMS]: new BadRequestError(

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,5 +1,10 @@
 import { AuthController } from './auth.controller';
 import { UserController } from './users.controller';
 import { TopicController } from './topic.controller';
+import { TargetController } from './targets.controller';
 
-export const controllers = [AuthController, UserController, TopicController];
+export const controllers = [
+  AuthController,
+  UserController,
+  TopicController,
+  TargetController];

--- a/src/controllers/targets.controller.ts
+++ b/src/controllers/targets.controller.ts
@@ -1,0 +1,39 @@
+import {
+  JsonController,
+  Body,
+  Post,
+  Authorized,
+  BadRequestError,
+  CurrentUser
+} from 'routing-controllers';
+import { Service } from 'typedi';
+import { ErrorsMessages } from '../constants/errorMessages';
+import { EntityMapper } from '@clients/mapper/entityMapper.service';
+import { TargetsService } from '@services/targets.service';
+import { CreateTargetDTO } from '@dto/createTargetDTO';
+import { Target } from '@entities/target.entity';
+import { ITokenPayload } from 'src/interfaces/auth/auth.interface';
+
+@JsonController('/targets')
+@Service()
+export class TargetController {
+  constructor(private readonly targetsService: TargetsService) { }
+
+  @Authorized()
+  @Post()
+  async createTarget(
+    @Body() targetDTO: CreateTargetDTO,
+    @CurrentUser() currentUser: ITokenPayload
+  ): Promise<Target> {
+    try {
+      return await this.targetsService.createTarget(
+        EntityMapper.mapTo(Target, targetDTO),
+        currentUser.data.userId
+      );
+    } catch (error: any) {
+      throw new BadRequestError(
+        error.detail ?? error.message ?? ErrorsMessages.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+}

--- a/src/controllers/targets.controller.ts
+++ b/src/controllers/targets.controller.ts
@@ -26,10 +26,11 @@ export class TargetController {
     @CurrentUser() currentUser: ITokenPayload
   ): Promise<Target> {
     try {
-      return await this.targetsService.createTarget(
+      const target = await this.targetsService.createTarget(
         EntityMapper.mapTo(Target, targetDTO),
         currentUser.data.userId
       );
+      return target;
     } catch (error: any) {
       throw new BadRequestError(
         error.detail ?? error.message ?? ErrorsMessages.INTERNAL_SERVER_ERROR

--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -44,9 +44,10 @@ export class UserController {
   @Post()
   async post(@Body() userDTO: SignUpDTO): Promise<InsertResult> {
     try {
-      return await this.usersService.createUser(
+      const user = await this.usersService.createUser(
         EntityMapper.mapTo(User, userDTO)
       );
+      return user;
     } catch (error: any) {
       throw new BadRequestError(
         error.detail ?? error.message ?? ErrorsMessages.INTERNAL_SERVER_ERROR

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,4 +1,4 @@
-import { createConnection, getConnection, Connection } from 'typeorm';
+import { createConnection, getConnection, Connection, DeleteResult } from 'typeorm';
 import config from '@ormconfig';
 
 const connection = {
@@ -21,11 +21,11 @@ const connection = {
     const connection = getConnection();
     const entities = connection.entityMetadatas;
 
-    const reposToClear: Promise<void>[] = [];
+    const reposToClear: Promise<DeleteResult>[] = [];
     entities.forEach(entity => {
       const repository = connection.getRepository(entity.name);
       try {
-        reposToClear.push(repository.clear());
+        reposToClear.push(repository.delete({}));
       } catch (error) {
         throw new Error(`ERROR: Cleaning test db: ${error}`);
       }

--- a/src/database/factories/createTargetDTO.factory.ts
+++ b/src/database/factories/createTargetDTO.factory.ts
@@ -1,0 +1,13 @@
+import * as Faker from 'faker';
+import { define } from 'typeorm-seeding';
+import { CreateTargetDTO } from '@dto/createTargetDTO';
+
+define(CreateTargetDTO, (faker: typeof Faker) => {
+  const latitude = faker.address.latitude();
+  const longitude = faker.address.longitude();
+  const createTargetDTO = new CreateTargetDTO(latitude, longitude);
+  createTargetDTO.title = faker.random.word();
+  createTargetDTO.radius = faker.random.number();
+
+  return createTargetDTO;
+});

--- a/src/database/factories/createTargetDTO.factory.ts
+++ b/src/database/factories/createTargetDTO.factory.ts
@@ -6,7 +6,7 @@ define(CreateTargetDTO, (faker: typeof Faker) => {
   const latitude = faker.address.latitude();
   const longitude = faker.address.longitude();
   const createTargetDTO = new CreateTargetDTO(latitude, longitude);
-  createTargetDTO.title = faker.random.word();
+  createTargetDTO.title = faker.random.word()+faker.random.word();
   createTargetDTO.radius = faker.random.number();
 
   return createTargetDTO;

--- a/src/database/factories/target.factory.ts
+++ b/src/database/factories/target.factory.ts
@@ -1,0 +1,13 @@
+import * as Faker from 'faker';
+import { define } from 'typeorm-seeding';
+import { Target } from '@entities/target.entity';
+
+define(Target, (faker: typeof Faker) => {
+  const latitude = faker.address.latitude();
+  const longitude = faker.address.longitude();
+  const target = new Target(latitude, longitude);
+  target.title = faker.random.word();
+  target.radius = faker.random.number();
+
+  return target;
+});

--- a/src/database/migrations/1642781136073-EmailVerificationUser.ts
+++ b/src/database/migrations/1642781136073-EmailVerificationUser.ts
@@ -8,7 +8,7 @@ export class EmailVerificationUser1642781136073 implements MigrationInterface {
       `  
         ALTER TABLE "user" ADD "verified" boolean NOT NULL DEFAULT false;
         ALTER TABLE "user" ADD "verifyHash" uuid DEFAULT uuid_generate_v4();
-        ALTER TABLE "user" ADD "hashExpiresAt" TIMESTAMP DEFAULT NOW() +INTERVAL '1 day;
+        ALTER TABLE "user" ADD "hashExpiresAt" TIMESTAMP DEFAULT NOW() +INTERVAL '1' day;
       `
     );
   }

--- a/src/database/migrations/1643377364415-CreateTargetEntity.ts
+++ b/src/database/migrations/1643377364415-CreateTargetEntity.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTargetEntity1643377364415 implements MigrationInterface {
+  name = 'CreateTargetEntity1643377364415';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "target" (
+        "id" SERIAL NOT NULL, 
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(), 
+        "updated_at" TIMESTAMP NOT NULL DEFAULT now(), 
+        "title" character varying NOT NULL, 
+        "radius" integer NOT NULL, 
+        "location" point NOT NULL, 
+        "userId" integer, 
+        CONSTRAINT "PK_9d962204b13c18851ea88fc72f3" PRIMARY KEY ("id")
+      );
+      ALTER TABLE "target" 
+        ADD CONSTRAINT "FK_de25ee089655161469f630c63f0" FOREIGN KEY ("userId")
+         REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE
+    `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+        ALTER TABLE "target" DROP CONSTRAINT "FK_de25ee089655161469f630c63f0";
+        DROP TABLE "target";`
+    );
+  }
+}

--- a/src/dto/createTargetDTO.ts
+++ b/src/dto/createTargetDTO.ts
@@ -4,14 +4,14 @@ export class CreateTargetDTO {
   constructor(latitude: string, longitude: string) {
     this.location = `${latitude},${longitude}`;
   }
+  @MinLength(4, { message: 'title should have a minimum length of $constraint1' })
   @IsString()
   @IsNotEmpty()
-  @MinLength(4, { message: 'title should have a minimum length of $constraint1' })
   title: string;
 
+  @Min(0, { message: 'radius must be greater than 0' })
   @IsNumber({}, { message: 'radius must be a number' })
   @IsNotEmpty()
-  @Min(0, { message: 'radius must be greater than 0' })
   radius: number;
 
   @IsString()

--- a/src/dto/createTargetDTO.ts
+++ b/src/dto/createTargetDTO.ts
@@ -1,0 +1,20 @@
+import { IsNotEmpty, IsNumber, IsString, Min, MinLength } from 'class-validator';
+
+export class CreateTargetDTO {
+  constructor(latitude: string, longitude: string) {
+    this.location = `${latitude},${longitude}`;
+  }
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(4, { message: 'title should have a minimum length of $constraint1' })
+  title: string;
+
+  @IsNumber({}, { message: 'radius must be a number' })
+  @IsNotEmpty()
+  @Min(0, { message: 'radius must be greater than 0' })
+  radius: number;
+
+  @IsString()
+  @IsNotEmpty()
+  location: string;
+}

--- a/src/dto/signUpDTO.ts
+++ b/src/dto/signUpDTO.ts
@@ -3,12 +3,15 @@ import { BaseUserDTO } from './baseUserDTO';
 import { Gender } from '@constants/users/attributes.constants';
 
 export class SignUpDTO extends BaseUserDTO {
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   firstName!: string;
 
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   lastName!: string;
 
-  @IsNotEmpty() @IsEnum( Gender )
+  @IsEnum( Gender )
+  @IsNotEmpty()
   gender!: Gender;
 }

--- a/src/entities/target.entity.ts
+++ b/src/entities/target.entity.ts
@@ -23,6 +23,5 @@ export class Target extends Base {
   @ManyToOne(() => User, user => user.targets,
     { onDelete: 'CASCADE', onUpdate: 'CASCADE' }
   )
-
   user: User;
 }

--- a/src/entities/target.entity.ts
+++ b/src/entities/target.entity.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { Base } from './base.entity';
+import { User } from './user.entity';
+
+@Entity()
+export class Target extends Base {
+  constructor(latitude: string, longitude: string) {
+    super();
+    this.location = `${latitude},${longitude}`;
+  }
+  @Column()
+  title: string;
+
+  @Column()
+  radius: number;
+
+  @Column({ type: 'point' })
+  location: string;
+
+  @Column()
+  userId: number;
+
+  @ManyToOne(() => User, user => user.targets,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' }
+  )
+
+  user: User;
+}

--- a/src/entities/topic.entity.ts
+++ b/src/entities/topic.entity.ts
@@ -1,4 +1,3 @@
-import { IsUrl, MinLength } from 'class-validator';
 import { Column, Entity } from 'typeorm';
 import { Base } from './base.entity';
 
@@ -11,10 +10,8 @@ export class Topic extends Base {
   }
 
   @Column()
-  @MinLength(4)
   name: string;
 
   @Column()
-  @IsUrl()
   image: string;
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, Generated, Index } from 'typeorm';
+import { Column, Entity, Generated, Index, OneToMany } from 'typeorm';
 import { Base } from './base.entity';
 import { Gender } from '@constants/users/attributes.constants';
+import { Target } from './target.entity';
 
 @Entity()
 export class User extends Base {
@@ -30,4 +31,7 @@ export class User extends Base {
   // eslint-disable-next-line quotes
   @Column({ nullable: true, type: 'timestamp', default: () => `NOW() +INTERVAL '1 day'` })
   hashExpiresAt: Date | null;
+
+  @OneToMany(() => Target, target => target.user )
+    targets: Target[];
 }

--- a/src/exception/targets/target-not-saved.exception.ts
+++ b/src/exception/targets/target-not-saved.exception.ts
@@ -1,0 +1,13 @@
+import { HttpStatusCode } from '@constants/httpStatusCode';
+import { ErrorsMessages, TargetErrorsMessages } from '@constants/errorMessages';
+import { BaseError } from '../base.error';
+
+export class TargetNotSavedException extends BaseError {
+  constructor( description: string ) {
+    super(
+      ErrorsMessages.BAD_REQUEST_ERROR,
+      HttpStatusCode.BAD_REQUEST,
+      `${TargetErrorsMessages.TARGET_NOT_SAVED}: ${description}`
+    );
+  }
+}

--- a/src/exception/users/hash-expired.error.ts
+++ b/src/exception/users/hash-expired.error.ts
@@ -1,5 +1,5 @@
 import { HttpStatusCode } from '@constants/httpStatusCode';
-import { ErrorsMessages } from '@constants/errorMessages';
+import { ErrorsMessages, UserErrorsMessages } from '@constants/errorMessages';
 import { BaseError } from '../base.error';
 
 export class HashExpiredError extends BaseError {
@@ -7,7 +7,7 @@ export class HashExpiredError extends BaseError {
     super(
       ErrorsMessages.NOT_ACCEPTABLE_ERROR,
       HttpStatusCode.NOT_ACCEPTABLE,
-      ErrorsMessages.HASH_EXPIRED
+      UserErrorsMessages.HASH_EXPIRED
     );
   }
 }

--- a/src/exception/users/hash-invalid.error.ts
+++ b/src/exception/users/hash-invalid.error.ts
@@ -1,5 +1,5 @@
 import { HttpStatusCode } from '@constants/httpStatusCode';
-import { ErrorsMessages } from '@constants/errorMessages';
+import { ErrorsMessages, UserErrorsMessages } from '@constants/errorMessages';
 import { BaseError } from '../base.error';
 
 export class HashInvalidError extends BaseError {
@@ -7,7 +7,7 @@ export class HashInvalidError extends BaseError {
     super(
       ErrorsMessages.BAD_REQUEST_ERROR,
       HttpStatusCode.BAD_REQUEST,
-      ErrorsMessages.HASH_NOT_VALID
+      UserErrorsMessages.HASH_NOT_VALID
     );
   }
 }

--- a/src/exception/users/user-not-found.error.ts
+++ b/src/exception/users/user-not-found.error.ts
@@ -1,5 +1,5 @@
 import { HttpStatusCode } from '@constants/httpStatusCode';
-import { ErrorsMessages } from '@constants/errorMessages';
+import { ErrorsMessages, UserErrorsMessages } from '@constants/errorMessages';
 import { BaseError } from '../base.error';
 
 export class UserNotFoundError extends BaseError {
@@ -7,7 +7,7 @@ export class UserNotFoundError extends BaseError {
     super(
       ErrorsMessages.NOT_FOUND_ERROR,
       HttpStatusCode.NOT_FOUND,
-      ErrorsMessages.USER_NOT_FOUND
+      UserErrorsMessages.USER_NOT_FOUND
     );
   }
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -6,7 +6,8 @@ import { ITokenPayload } from 'src/interfaces/auth/auth.interface';
 
 export class AuthorizationService {
   private static instance: AuthorizationService;
-
+  private static jwt = Container.get(JWTService);
+  private static redis = Container.get(RedisService);
   public static getInstance(): AuthorizationService {
     if (!this.instance) {
       this.instance = new AuthorizationService();
@@ -15,68 +16,47 @@ export class AuthorizationService {
     return this.instance;
   }
 
-  async authorizationChecker(
-    action: Action,
-    _roles: string[]
-  ): Promise<boolean> {
-    const jwt = Container.get(JWTService);
-    const redis = Container.get(RedisService);
+  async getUserFromToken( token: string ): Promise<ITokenPayload | undefined> {
     try {
-      let token = action.request.headers['authorization'];
       if (!token) {
-        return false;
+        return undefined;
       }
       if (token.startsWith('Bearer ')) {
         // Remove Bearer from authentication scheme header
         token = token.replace('Bearer ', '');
       }
-      const payload = await jwt.verifyJWT(token);
+      const payload = await AuthorizationService.jwt.verifyJWT(token);
       const {
         data: { email }
       } = payload;
-      const tokenIsBlacklisted: number = await redis.isMemberOfSet({
+      const tokenIsBlacklisted: number = await AuthorizationService.redis.isMemberOfSet({
         email,
         token
       });
       if (!!tokenIsBlacklisted) {
-        return false;
-      }
-      return true;
-    } catch (error) {
-      // Here we should do something with the error like loggin
-      return false;
-    }
-  }
-
-  async currentUserChecker(
-    action: Action
-  ): Promise<ITokenPayload | boolean> {
-    const jwt = Container.get(JWTService);
-    const redis = Container.get(RedisService);
-    try {
-      let token = action.request.headers['authorization'];
-      if (!token) {
-        return false;
-      }
-      if (token.startsWith('Bearer ')) {
-        // Remove Bearer from authentication scheme header
-        token = token.replace('Bearer ', '');
-      }
-      const payload = await jwt.verifyJWT(token);
-      const {
-        data: { email }
-      } = payload;
-      const tokenIsBlacklisted: number = await redis.isMemberOfSet({
-        email,
-        token
-      });
-      if (!!tokenIsBlacklisted) {
-        return false;
+        return undefined;
       }
       return payload;
     } catch (error) {
       // Here we should do something with the error like loggin
-      return false;
+      return undefined;
     }
+  }
+
+  async authorizationChecker(
+    action: Action,
+    _roles: string[]
+  ): Promise<boolean> {
+    const token = action.request.headers['authorization'];
+    const valid = await AuthorizationService.instance.getUserFromToken(token);
+    return !!valid;
+  }
+
+  async currentUserChecker(
+    action: Action
+  ): Promise<ITokenPayload | undefined> {
+    const token = action.request.headers['authorization'];
+    const payload = await AuthorizationService.instance.getUserFromToken(token);
+    return payload;
   }
 }

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -19,10 +19,11 @@ export class SessionService {
 
   private readonly userRepository = getRepository<User>(User);
 
-  async signUp(user: User) {
-    this.userService.hashUserPassword(user);
+  async signUp(userData: User) {
+    this.userService.hashUserPassword(userData);
     try {
-      return await this.userRepository.save(user);
+      const user = await this.userRepository.save(userData);
+      return user;
     } catch (error) {
       throw new DatabaseError(UserErrorsMessages.USER_ALREADY_EXISTS);
     }

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -1,4 +1,4 @@
-import { ErrorsMessages } from '@constants/errorMessages';
+import { ErrorsMessages, UserErrorsMessages } from '@constants/errorMessages';
 import { Service } from 'typedi';
 import { getRepository } from 'typeorm';
 import { User } from '@entities/user.entity';
@@ -24,7 +24,7 @@ export class SessionService {
     try {
       return await this.userRepository.save(user);
     } catch (error) {
-      throw new DatabaseError(ErrorsMessages.USER_ALREADY_EXISTS);
+      throw new DatabaseError(UserErrorsMessages.USER_ALREADY_EXISTS);
     }
   }
 

--- a/src/services/targets.service.ts
+++ b/src/services/targets.service.ts
@@ -1,0 +1,33 @@
+import { Service } from 'typedi';
+import { getRepository } from 'typeorm';
+import { Target } from '@entities/target.entity';
+import { TargetNotSavedException } from '@exception/targets/target-not-saved.exception';
+import { TargetErrorsMessages } from '@constants/errorMessages';
+
+@Service()
+export class TargetsService {
+  private readonly targetRepository = getRepository<Target>(Target);
+
+  async canCreateTargets(userId: number): Promise<boolean> {
+    try {
+      const numberTargets = await this.targetRepository.count({ where: { userId } });
+      return numberTargets < 10;
+    } catch (error) {
+      throw new Error(`${error}`);
+    }
+  }
+
+  async createTarget(target: Target, userId: number): Promise<Target> {
+    try {
+      const canCreate = await this.canCreateTargets(userId);
+      if (!canCreate) {
+        throw new Error(TargetErrorsMessages.TARGET_USER_MORE_10);
+      }
+      target.userId = userId;
+      const targetResult = await this.targetRepository.save(target);
+      return targetResult;
+    } catch (error) {
+      throw new TargetNotSavedException(`${error}`);
+    }
+  }
+}


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- The user cannot create targets in order to find people with similar interests in the map.

Issue Link: 

- [Issue 1](https://trello.com/c/A3lVD2dT/3-3-as-a-user-i-should-be-able-to-create-a-new-target-so-i-can-find-people-with-similar-interests-in-a-specific-area)
- [Issue 2](https://trello.com/c/itW4Cg6E/5-2-as-a-user-i-should-only-be-able-to-create-a-maximum-of-10-targets-so-the-map-doesnt-get-too-crowded)

## What is the new behavior?

- Now the user can create targets on the map, with a title, a position on the map based on latitude and longitude and a radius of effect.

## Other information

<!-- Please add any relevant information that assists the code review. -->
- The user must be authenticated to create the targets.
- The user can create a maximum of 10 targets.

## Preview

N/A
