### PR TITLE
Add target match functionality

### DIFF
--- a/__tests__/repositories/targets.repository.spec.ts
+++ b/__tests__/repositories/targets.repository.spec.ts
@@ -1,0 +1,75 @@
+/* eslint-disable camelcase */
+import { getCustomRepository } from 'typeorm';
+import { mocked } from 'ts-jest/utils';
+import { factory } from 'typeorm-seeding';
+import { Target } from '@entities/target.entity';
+import { TargetRepository } from '@repositories/targets.repository';
+import { mockQueryBuilder } from '../utils/mocks';
+
+let target: Target;
+let targetRepository: Partial<TargetRepository>;
+jest.mock('typeorm', () => {
+  const actual = jest.requireActual('typeorm');
+  return {
+    ...actual,
+    getCustomRepository: jest.fn()
+  };
+});
+
+mocked(getCustomRepository).mockReturnValue(new TargetRepository);
+describe('TargetRepository', () => {
+  beforeAll( () => {
+    targetRepository = getCustomRepository(TargetRepository);
+  });
+
+  it('all dependencies should be defined', () => {
+    expect(targetRepository).toBeDefined();
+  });
+
+  describe('findBy', ( ) => {
+    beforeEach( async ( ) => {
+      target = await factory(Target)().make({ awaiting_cron: true });
+    });
+
+    it('should return list of targets when criteria found on database', async ( ) => {
+      targetRepository.createQueryBuilder = mockQueryBuilder(
+        { getManyResponse: [target] }
+      );
+      const targetsFound = await targetRepository.findBy({ awaiting_cron: true });
+      expect(targetsFound).toBeInstanceOf(Array);
+      expect(targetsFound).not.toHaveLength(0);
+      expect(targetsFound.every(
+        (target: Target) => target.awaiting_cron === true)
+      ).toBe(true);
+    });
+
+    it('should return an empty list when criteria not found on database', async ( ) => {
+      targetRepository.createQueryBuilder = mockQueryBuilder(
+        { getManyResponse: [] }
+      );
+      const targetsFound = await targetRepository.findBy({ awaiting_cron: true });
+      expect(targetsFound).toBeInstanceOf(Array);
+      expect(targetsFound).toHaveLength(0);
+    });
+  });
+
+  describe('showTargets', () => {
+    it('should return list of targets when requested', async ( ) => {
+      targetRepository.createQueryBuilder = mockQueryBuilder(
+        { getManyResponse: [target] }
+      );
+      const targetsFound = await targetRepository.showTargets();
+      expect(targetsFound).toBeInstanceOf(Array);
+      expect(targetsFound).not.toHaveLength(0);
+    });
+
+    it('should return empty list of targets when no existing targets', async ( ) => {
+      targetRepository.createQueryBuilder = mockQueryBuilder(
+        { getManyResponse: [] }
+      );
+      const targetsFound = await targetRepository.showTargets();
+      expect(targetsFound).toBeInstanceOf(Array);
+      expect(targetsFound).toHaveLength(0);
+    });
+  });
+});

--- a/__tests__/repositories/targets.repository.spec.ts
+++ b/__tests__/repositories/targets.repository.spec.ts
@@ -26,33 +26,6 @@ describe('TargetRepository', () => {
     expect(targetRepository).toBeDefined();
   });
 
-  describe('findBy', ( ) => {
-    beforeEach( async ( ) => {
-      target = await factory(Target)().make({ awaiting_cron: true });
-    });
-
-    it('should return list of targets when criteria found on database', async ( ) => {
-      targetRepository.createQueryBuilder = mockQueryBuilder(
-        { getManyResponse: [target] }
-      );
-      const targetsFound = await targetRepository.findBy({ awaiting_cron: true });
-      expect(targetsFound).toBeInstanceOf(Array);
-      expect(targetsFound).not.toHaveLength(0);
-      expect(targetsFound.every(
-        (target: Target) => target.awaiting_cron === true)
-      ).toBe(true);
-    });
-
-    it('should return an empty list when criteria not found on database', async ( ) => {
-      targetRepository.createQueryBuilder = mockQueryBuilder(
-        { getManyResponse: [] }
-      );
-      const targetsFound = await targetRepository.findBy({ awaiting_cron: true });
-      expect(targetsFound).toBeInstanceOf(Array);
-      expect(targetsFound).toHaveLength(0);
-    });
-  });
-
   describe('showTargets', () => {
     it('should return list of targets when requested', async ( ) => {
       targetRepository.createQueryBuilder = mockQueryBuilder(

--- a/__tests__/repositories/targets.repository.spec.ts
+++ b/__tests__/repositories/targets.repository.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 import { getCustomRepository } from 'typeorm';
 import { mocked } from 'ts-jest/utils';
-import { factory } from 'typeorm-seeding';
 import { Target } from '@entities/target.entity';
 import { TargetRepository } from '@repositories/targets.repository';
 import { mockQueryBuilder } from '../utils/mocks';

--- a/__tests__/services/targets.service.spec.ts
+++ b/__tests__/services/targets.service.spec.ts
@@ -14,6 +14,7 @@ import { mockUpdateResult } from '../utils/mocks';
 import { TargetRepository } from '@repositories/targets.repository';
 import { TargetsService } from '@services/targets.service';
 import { mockTargetRepository } from '../utils/repositories/target.repository.mock';
+import { createTargets } from '../utils/targets';
 
 let targetsService: TargetsService;
 let usersService: UsersService;
@@ -46,7 +47,6 @@ describe('TargetsService', () => {
     expect(targetsService).toBeDefined();
     expect(usersService).toBeDefined();
     expect(targetRepository).toBeDefined();
-    expect(getCustomRepository).toReturnWith(mockTargetRepository);
   });
 
   describe('canCreateTargets', () => {
@@ -171,12 +171,9 @@ describe('TargetsService', () => {
   });
 
   describe('showTargetsByTopic', ( ) => {
-    const targets: Target[] = [];
+    let targets: Target[];
     beforeEach( async ( ) => {
-      for (let i = 1; i<4; i++) {
-        target = await factory(Target)().make({ userId: i, topicId: i });
-        targets.push(target);
-      }
+      targets = await createTargets(3);
     });
 
     it('should retrieve the targets segmented by topic when requested', async ( ) => {
@@ -201,30 +198,22 @@ describe('TargetsService', () => {
     });
 
     it('should return an array with targets when there are targets that matched', async ( ) => {
-      for (let i = 1; i<4; i++) {
-        target = await factory(Target)().make({
-          userId: i,
-          topicId: 1,
-          awaiting_cron: true,
-          location: '50,50'
-        });
-        targets.push(target);
-      }
+      targets = await createTargets(3, {
+        topicId: 1,
+        awaiting_cron: true,
+        location: '50,50'
+      });
       const targetsMatched = targetsService.getTargetsMatched(targets);
       expect(targetsMatched).toBeInstanceOf(Array);
       expect(targetsMatched).not.toHaveLength(0);
     });
 
     it('should return an empty array when no targets matched', async ( ) => {
-      for (let i = 1; i<4; i++) {
-        target = await factory(Target)().make({
-          userId: 1,
-          topicId: i,
-          awaiting_cron: true,
-          location: '50,50'
-        });
-        targets.push(target);
-      }
+      targets = await createTargets(3, {
+        userId: 1,
+        awaiting_cron: true,
+        location: '50,50'
+      });
       const targetsMatched = targetsService.getTargetsMatched(targets);
       expect(targetsMatched).toBeInstanceOf(Array);
       expect(targetsMatched).toHaveLength(0);

--- a/__tests__/utils/mocks.ts
+++ b/__tests__/utils/mocks.ts
@@ -5,24 +5,33 @@ export const mockInsertResult = new InsertResult();
 export const mockDeleteResult = new DeleteResult();
 
 export interface IMockedQueryBuilderResponses {
+  executeResponse?: unknown;
   getOneResponse?: unknown;
   getOneOrFailResponse?: unknown;
   getManyAndCountResponse?: unknown[];
+  getManyResponse?: unknown[];
 }
 
-export function mockQueryBuilder(expectedResponse: IMockedQueryBuilderResponses) {
+export function mockQueryBuilder(expectedResponse: IMockedQueryBuilderResponses): any {
   return jest.fn().mockImplementationOnce((_alias: string) => {
     return {
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      innerJoinAndSelect: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      execute: expectedResponse.executeResponse instanceof Error ?
+        jest.fn().mockRejectedValue(expectedResponse.executeResponse) :
+        jest.fn().mockResolvedValue(expectedResponse.executeResponse),
       getOne: jest.fn().mockResolvedValue(expectedResponse.getOneResponse),
       getOneOrFail: expectedResponse.getOneOrFailResponse instanceof Error ?
-        jest.fn().mockRejectedValue(new Error())
-        : jest.fn().mockResolvedValue(expectedResponse.getOneOrFailResponse),
+        jest.fn().mockRejectedValue(expectedResponse.getOneOrFailResponse) :
+        jest.fn().mockResolvedValue(expectedResponse.getOneOrFailResponse),
       getManyAndCount: jest.fn().mockResolvedValue(
         [expectedResponse.getManyAndCountResponse,
           expectedResponse.getManyAndCountResponse?.length || 0
-        ])
+        ]),
+      getMany: jest.fn().mockResolvedValue(expectedResponse.getManyResponse)
     };
   });
 }

--- a/__tests__/utils/repositories/target.repository.mock.ts
+++ b/__tests__/utils/repositories/target.repository.mock.ts
@@ -1,6 +1,4 @@
 /* eslint-disable camelcase */
-import { factory } from 'typeorm-seeding';
-import { Target } from '@entities/target.entity';
 import { TargetRepository } from '@repositories/targets.repository';
 
 export const mockTargetRepository: Partial<TargetRepository> = {
@@ -9,13 +7,6 @@ export const mockTargetRepository: Partial<TargetRepository> = {
   find: jest.fn().mockReturnThis(),
   softDelete: jest.fn().mockReturnThis(),
   showTargets: jest.fn().mockImplementation( async ( ) => {
-    return mockTargetRepository.createQueryBuilder().getMany();
-  }),
-  findBy: jest.fn().mockImplementation( async (
-    criteria: Partial<Target>
-  ) => {
-    const targetFound = await factory(Target)().make();
-    criteria.awaiting_cron && ( targetFound.awaiting_cron = criteria.awaiting_cron );
     return mockTargetRepository.createQueryBuilder().getMany();
   })
 };

--- a/__tests__/utils/repositories/target.repository.mock.ts
+++ b/__tests__/utils/repositories/target.repository.mock.ts
@@ -1,8 +1,21 @@
+/* eslint-disable camelcase */
+import { factory } from 'typeorm-seeding';
+import { Target } from '@entities/target.entity';
 import { TargetRepository } from '@repositories/targets.repository';
 
 export const mockTargetRepository: Partial<TargetRepository> = {
   count: jest.fn().mockReturnThis(),
   save: jest.fn().mockReturnThis(),
   find: jest.fn().mockReturnThis(),
-  softDelete: jest.fn().mockReturnThis()
+  softDelete: jest.fn().mockReturnThis(),
+  showTargets: jest.fn().mockImplementation( async ( ) => {
+    return mockTargetRepository.createQueryBuilder().getMany();
+  }),
+  findBy: jest.fn().mockImplementation( async (
+    criteria: Partial<Target>
+  ) => {
+    const targetFound = await factory(Target)().make();
+    criteria.awaiting_cron && ( targetFound.awaiting_cron = criteria.awaiting_cron );
+    return mockTargetRepository.createQueryBuilder().getMany();
+  })
 };

--- a/__tests__/utils/targets.ts
+++ b/__tests__/utils/targets.ts
@@ -1,0 +1,12 @@
+/* eslint-disable camelcase */
+/* eslint-disable max-len */
+import { Target } from '@entities/target.entity';
+import { factory } from 'typeorm-seeding';
+
+export async function createTargets( amount: number, data?: Partial<Target> ): Promise<Target[]> {
+  const targets = [];
+  for (let i=0; i<amount; i++) {
+    targets.push( await factory(Target)().make(data) );
+  }
+  return targets;
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "express": "^4.17.2",
     "express-formidable": "^1.2.0",
     "express-rate-limit": "^6.0.4",
+    "geolib": "^3.3.3",
     "helmet": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",

--- a/src/database/factories/target.factory.ts
+++ b/src/database/factories/target.factory.ts
@@ -8,6 +8,8 @@ define(Target, (faker: typeof Faker) => {
   const target = new Target(latitude, longitude);
   target.title = faker.random.word();
   target.radius = faker.random.number();
+  target.userId = faker.random.number();
+  target.topicId = faker.random.number();
 
   return target;
 });

--- a/src/dto/createTargetDTO.ts
+++ b/src/dto/createTargetDTO.ts
@@ -17,4 +17,8 @@ export class CreateTargetDTO {
   @IsString()
   @IsNotEmpty()
   location: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  topicId: string;
 }

--- a/src/entities/target.entity.ts
+++ b/src/entities/target.entity.ts
@@ -1,5 +1,7 @@
+/* eslint-disable camelcase */
 import { Column, DeleteDateColumn, Entity, ManyToOne } from 'typeorm';
 import { Base } from './base.entity';
+import { Topic } from './topic.entity';
 import { User } from './user.entity';
 
 @Entity()
@@ -20,6 +22,12 @@ export class Target extends Base {
   @Column()
   userId: number;
 
+  @Column()
+  topicId: number;
+
+  @Column({ default: true })
+  awaiting_cron: boolean;
+
   @DeleteDateColumn()
   deletedAt: Date | null;
 
@@ -27,4 +35,9 @@ export class Target extends Base {
     { onDelete: 'CASCADE', onUpdate: 'CASCADE' }
   )
   user: User;
+
+  @ManyToOne(() => Topic, topic => topic.targets,
+    { onDelete: 'CASCADE', onUpdate: 'CASCADE' }
+  )
+  topic: Topic;
 }

--- a/src/entities/topic.entity.ts
+++ b/src/entities/topic.entity.ts
@@ -1,5 +1,6 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
 import { Base } from './base.entity';
+import { Target } from './target.entity';
 
 @Entity()
 export class Topic extends Base {
@@ -14,4 +15,7 @@ export class Topic extends Base {
 
   @Column()
   image: string;
+
+  @OneToMany(() => Target, target => target.topic )
+  targets: Target[];
 }

--- a/src/repositories/targets.repository.ts
+++ b/src/repositories/targets.repository.ts
@@ -11,12 +11,4 @@ export class TargetRepository extends Repository<Target> {
       .getMany();
     return targets;
   }
-
-  async findBy(criteria: Partial<Target>): Promise<Target[]> {
-    const query = this.createQueryBuilder( );
-    criteria.awaiting_cron && query.andWhere('awaiting_cron = :awaiting_cron',
-      { awaiting_cron: criteria.awaiting_cron }
-    );
-    return query.getMany();
-  }
 }

--- a/src/repositories/targets.repository.ts
+++ b/src/repositories/targets.repository.ts
@@ -1,7 +1,22 @@
+/* eslint-disable camelcase */
 import { EntityRepository, Repository } from 'typeorm';
 import { Target } from '@entities/target.entity';
 
 @EntityRepository(Target)
 export class TargetRepository extends Repository<Target> {
+  async showTargets(): Promise<Target[]> {
+    const targets = this.createQueryBuilder('target')
+      .innerJoinAndSelect('target.user', 'user')
+      .innerJoinAndSelect('target.topic', 'topic')
+      .getMany();
+    return targets;
+  }
 
+  async findBy(criteria: Partial<Target>): Promise<Target[]> {
+    const query = this.createQueryBuilder( );
+    criteria.awaiting_cron && query.andWhere('awaiting_cron = :awaiting_cron',
+      { awaiting_cron: criteria.awaiting_cron }
+    );
+    return query.getMany();
+  }
 }

--- a/src/services/targets.service.ts
+++ b/src/services/targets.service.ts
@@ -1,5 +1,6 @@
 import { Service } from 'typedi';
 import { getCustomRepository, UpdateResult } from 'typeorm';
+import { isPointWithinRadius } from 'geolib';
 import { Target } from '@entities/target.entity';
 import { TargetNotSavedException } from '@exception/targets/target-not-saved.exception';
 import { TargetErrorsMessages } from '@constants/errorMessages';
@@ -32,6 +33,45 @@ export class TargetsService {
     } catch (error) {
       throw new TargetNotSavedException(`${error}`);
     }
+  }
+
+  async showTargetsByTopic( ) {
+    const targets = await this.targetRepository.showTargets( );
+    const targetsByTopic = {};
+    targets.forEach( ( target: Target ) => {
+      if (!targetsByTopic.hasOwnProperty(target.topicId)) {
+        targetsByTopic[target.topicId] = [];
+      }
+      targetsByTopic[target.topicId].push(target);
+    });
+    return targetsByTopic;
+  }
+
+  getTargetsMatched( targets: Target[] ): Target[] {
+    const targetsMatched = [];
+    const newTargets = targets.filter( target => target.awaiting_cron );
+    newTargets.forEach( (newTarget: Target) => {
+      const newTargetPosition = {
+        latitude: newTarget.location[0],
+        longitude: newTarget.location[1]
+      };
+      targets.forEach( ( target: Target ) => {
+        if ( newTarget.userId !== target.userId ) {
+          const possibleMatchPosition = {
+            latitude: target.location[0],
+            longitude: target.location[1]
+          };
+          if ( isPointWithinRadius(
+            newTargetPosition,
+            possibleMatchPosition,
+            target.radius )
+          ) {
+            targetsMatched.push([newTarget, target]);
+          }
+        }
+      });
+    });
+    return targetsMatched;
   }
 
   async listTargets( userId: number ): Promise<Target[]> {

--- a/src/services/targets.service.ts
+++ b/src/services/targets.service.ts
@@ -49,8 +49,7 @@ export class TargetsService {
 
   getTargetsMatched( targets: Target[] ): Target[] {
     const targetsMatched = [];
-    const newTargets = targets.filter( target => target.awaiting_cron );
-    newTargets.forEach( (newTarget: Target) => {
+    targets.filter( target => target.awaiting_cron ).forEach( (newTarget: Target) => {
       const newTargetPosition = {
         latitude: newTarget.location[0],
         longitude: newTarget.location[1]

--- a/src/services/targets.service.ts
+++ b/src/services/targets.service.ts
@@ -66,7 +66,7 @@ export class TargetsService {
             possibleMatchPosition,
             target.radius )
           ) {
-            targetsMatched.push([newTarget, target]);
+            targetsMatched.push({ newTarget, target });
           }
         }
       });


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- The users can create targets with topics, but there is no way to check if they match.

Issue Link: [Issue](https://trello.com/c/yYLT13S7/8-5-as-a-user-i-should-receive-notifications-when-a-compatible-target-has-been-created-so-we-can-start-getting-connected)

## What is the new behavior?
- The targets can match between users.

## Other information

<!-- Please add any relevant information that assists the code review. -->
- Targets will match if they are within the same radius with the given latitude and longitude and are related to the same topic.

## Preview

N/A
